### PR TITLE
Automate Updates using Renovate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,17 +30,17 @@ RUN curl -sSL "https://github.com/grpc/grpc-web/releases/download/${GRPC_WEB_VER
     chmod +x /usr/local/bin/protoc-gen-web-grpc
 
 # https://pkg.go.dev/google.golang.org/protobuf/cmd/protoc-gen-go
-# renovate: datasource=github-releases depName=protoc-gen-go packageName=google.golang.org/protobuf
+# renovate: datasource=golang depName=protoc-gen-go packageName=google.golang.org/protobuf
 ARG PROTOBUF_GO_VERSION=1.36.3
 RUN GOBIN=/usr/local/bin go install google.golang.org/protobuf/cmd/protoc-gen-go@v${PROTOBUF_GO_VERSION}
 
 # https://pkg.go.dev/google.golang.org/grpc/cmd/protoc-gen-go-grpc
-# renovate: datasource=github-releases depName=protoc-gen-go packageName=google.golang.org/grpc
+# renovate: datasource=golang depName=protoc-gen-go packageName=google.golang.org/grpc
 ARG GRPC_GO_VERSION=1.5.1
 RUN GOBIN=/usr/local/bin go install "google.golang.org/grpc/cmd/protoc-gen-go-grpc@v${GRPC_GO_VERSION}"
 
 # https://github.com/bufbuild/buf
-# renovate: datasource=github-releases depName=buf packageName=bufbuild/buf
+# renovate: datasource=golang depName=buf packageName=bufbuild/buf
 ARG BUF_VERSION=1.50.0
 RUN GOBIN=/usr/local/bin go install \
     github.com/bufbuild/buf/cmd/buf@v${BUF_VERSION} \
@@ -48,9 +48,9 @@ RUN GOBIN=/usr/local/bin go install \
     github.com/bufbuild/buf/cmd/protoc-gen-buf-lint@v${BUF_VERSION}
 
 # Connect gRPC plugins
-# renovate: datasource=github-releases depName=protoc_gen_go packageName=protocolbuffers/protobuf-go
+# renovate: datasource=golang depName=protoc_gen_go packageName=protocolbuffers/protobuf-go
 ARG PROTOC_GEN_GO_VERSION=1.36.3
-# renovate: datasource=github-releases depName=protoc_gen_connect_go packageName=connectrpc/connect-go
+# renovate: datasource=golang depName=protoc_gen_connect_go packageName=connectrpc/connect-go
 ARG PROTOC_GEN_CONNECT_GO_VERSION=1.18.1
 RUN GOBIN=/usr/local/bin go install \
     connectrpc.com/connect/cmd/protoc-gen-connect-go@v${PROTOC_GEN_CONNECT_GO_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ ARG PROTOBUF_GO_VERSION=1.36.3
 RUN GOBIN=/usr/local/bin go install google.golang.org/protobuf/cmd/protoc-gen-go@v${PROTOBUF_GO_VERSION}
 
 # https://pkg.go.dev/google.golang.org/grpc/cmd/protoc-gen-go-grpc
-# renovate: datasource=go depName=protoc-gen-go packageName=google.golang.org/grpc/cmd/protoc-gen-go-grpc
+# renovate: datasource=go depName=protoc-gen-go-grpc packageName=google.golang.org/grpc/cmd/protoc-gen-go-grpc
 ARG GRPC_GO_VERSION=1.5.1
 RUN GOBIN=/usr/local/bin go install "google.golang.org/grpc/cmd/protoc-gen-go-grpc@v${GRPC_GO_VERSION}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,24 +30,24 @@ RUN curl -sSL "https://github.com/grpc/grpc-web/releases/download/${GRPC_WEB_VER
     chmod +x /usr/local/bin/protoc-gen-web-grpc
 
 # https://pkg.go.dev/google.golang.org/protobuf/cmd/protoc-gen-go
-# renovate: datasource=golang depName=protoc-gen-go packageName=google.golang.org/protobuf/cmd/protoc-gen-go
+# renovate: datasource=go depName=protoc-gen-go packageName=google.golang.org/protobuf/cmd/protoc-gen-go
 ARG PROTOBUF_GO_VERSION=1.36.3
 RUN GOBIN=/usr/local/bin go install google.golang.org/protobuf/cmd/protoc-gen-go@v${PROTOBUF_GO_VERSION}
 
 # https://pkg.go.dev/google.golang.org/grpc/cmd/protoc-gen-go-grpc
-# renovate: datasource=golang depName=protoc-gen-go packageName=google.golang.org/grpc/cmd/protoc-gen-go-grpc
+# renovate: datasource=go depName=protoc-gen-go packageName=google.golang.org/grpc/cmd/protoc-gen-go-grpc
 ARG GRPC_GO_VERSION=1.5.1
 RUN GOBIN=/usr/local/bin go install "google.golang.org/grpc/cmd/protoc-gen-go-grpc@v${GRPC_GO_VERSION}"
 
 # https://github.com/bufbuild/buf
-# renovate: datasource=golang depName=buf packageName=github.com/bufbuild/buf/cmd/buf
+# renovate: datasource=go depName=buf packageName=github.com/bufbuild/buf/cmd/buf
 ARG BUF_VERSION=1.50.0
 RUN GOBIN=/usr/local/bin go install \
     github.com/bufbuild/buf/cmd/buf@v${BUF_VERSION} \
     github.com/bufbuild/buf/cmd/protoc-gen-buf-breaking@v${BUF_VERSION} \
     github.com/bufbuild/buf/cmd/protoc-gen-buf-lint@v${BUF_VERSION}
 
-# renovate: datasource=golang depName=protoc_gen_connect_go packageName=connectrpc.com/connect/cmd/protoc-gen-connect-go
+# renovate: datasource=go depName=protoc_gen_connect_go packageName=connectrpc.com/connect/cmd/protoc-gen-connect-go
 ARG PROTOC_GEN_CONNECT_GO_VERSION=1.18.1
 RUN GOBIN=/usr/local/bin go install \
     connectrpc.com/connect/cmd/protoc-gen-connect-go@v${PROTOC_GEN_CONNECT_GO_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ ARG GRPC_NODE_TOOLS_VERSION=1.12.4
 # renovate: datasource=npm depName=buf-protoplugin packageName=@bufbuild/protoplugin
 ARG PROTOBUF_PROTOPLUGIN_VERSION=2.2.3
 # https://www.npmjs.com/package/@bufbuild/protoc-gen-es
-# renovate: datasource=github-npm depName=protobuf-gen-es packageName=@bufbuild/protoc-gen-es
+# renovate: datasource=npm depName=protobuf-gen-es packageName=@bufbuild/protoc-gen-es
 ARG PROTOBUF_ES_VERSION=2.2.3
 RUN npm i -g \
     grpc-tools@${GRPC_NODE_TOOLS_VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN GOBIN=/usr/local/bin go install \
     github.com/bufbuild/buf/cmd/protoc-gen-buf-breaking@v${BUF_VERSION} \
     github.com/bufbuild/buf/cmd/protoc-gen-buf-lint@v${BUF_VERSION}
 
-# renovate: datasource=go depName=protoc_gen_connect_go packageName=connectrpc.com/connect/cmd/protoc-gen-connect-go
+# renovate: datasource=github-releases depName=protoc_gen_connect_go packageName=connectrpc/connect-go
 ARG PROTOC_GEN_CONNECT_GO_VERSION=1.18.1
 RUN GOBIN=/usr/local/bin go install \
     connectrpc.com/connect/cmd/protoc-gen-connect-go@v${PROTOC_GEN_CONNECT_GO_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.23.1-bookworm AS base
+FROM --platform=linux/amd64 golang:1.23.5-bookworm AS base
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,27 +30,24 @@ RUN curl -sSL "https://github.com/grpc/grpc-web/releases/download/${GRPC_WEB_VER
     chmod +x /usr/local/bin/protoc-gen-web-grpc
 
 # https://pkg.go.dev/google.golang.org/protobuf/cmd/protoc-gen-go
-# renovate: datasource=golang depName=protoc-gen-go packageName=google.golang.org/protobuf
+# renovate: datasource=golang depName=protoc-gen-go packageName=google.golang.org/protobuf/cmd/protoc-gen-go
 ARG PROTOBUF_GO_VERSION=1.36.3
 RUN GOBIN=/usr/local/bin go install google.golang.org/protobuf/cmd/protoc-gen-go@v${PROTOBUF_GO_VERSION}
 
 # https://pkg.go.dev/google.golang.org/grpc/cmd/protoc-gen-go-grpc
-# renovate: datasource=golang depName=protoc-gen-go packageName=google.golang.org/grpc
+# renovate: datasource=golang depName=protoc-gen-go packageName=google.golang.org/grpc/cmd/protoc-gen-go-grpc
 ARG GRPC_GO_VERSION=1.5.1
 RUN GOBIN=/usr/local/bin go install "google.golang.org/grpc/cmd/protoc-gen-go-grpc@v${GRPC_GO_VERSION}"
 
 # https://github.com/bufbuild/buf
-# renovate: datasource=golang depName=buf packageName=bufbuild/buf
+# renovate: datasource=golang depName=buf packageName=github.com/bufbuild/buf/cmd/buf
 ARG BUF_VERSION=1.50.0
 RUN GOBIN=/usr/local/bin go install \
     github.com/bufbuild/buf/cmd/buf@v${BUF_VERSION} \
     github.com/bufbuild/buf/cmd/protoc-gen-buf-breaking@v${BUF_VERSION} \
     github.com/bufbuild/buf/cmd/protoc-gen-buf-lint@v${BUF_VERSION}
 
-# Connect gRPC plugins
-# renovate: datasource=golang depName=protoc_gen_go packageName=protocolbuffers/protobuf-go
-ARG PROTOC_GEN_GO_VERSION=1.36.3
-# renovate: datasource=golang depName=protoc_gen_connect_go packageName=connectrpc/connect-go
+# renovate: datasource=golang depName=protoc_gen_connect_go packageName=connectrpc.com/connect/cmd/protoc-gen-connect-go
 ARG PROTOC_GEN_CONNECT_GO_VERSION=1.18.1
 RUN GOBIN=/usr/local/bin go install \
     connectrpc.com/connect/cmd/protoc-gen-connect-go@v${PROTOC_GEN_CONNECT_GO_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,15 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /tmp
 
 # https://github.com/protocolbuffers/protobuf
-ARG PROTOBUF_VERSION
+# renovate: datasource=github-releases depName=protoc packageName=protocolbuffers/protobuf
+ARG PROTOBUF_VERSION=29.3
 RUN curl -sSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip" -o protoc.zip && \
     unzip protoc.zip -d protoc/ && \
     chmod +x ./protoc/bin/protoc
 
 # https://github.com/protocolbuffers/protobuf-javascript
-ARG PROTOBUF_JAVASCRIPT_VERSION
+# renovate: datasource=github-releases depName=protobuf-javascript packageName=protocolbuffers/protobuf-javascript
+ARG PROTOBUF_JAVASCRIPT_VERSION=3.21.4
 RUN curl -sSL "https://github.com/protocolbuffers/protobuf-javascript/releases/download/v${PROTOBUF_JAVASCRIPT_VERSION}/protobuf-javascript-${PROTOBUF_JAVASCRIPT_VERSION}-linux-x86_64.zip" \
     -o protoc-gen-js.zip && \
     unzip protoc-gen-js.zip -d protoc-gen-js/ && \
@@ -22,29 +24,36 @@ RUN curl -sSL "https://github.com/protocolbuffers/protobuf-javascript/releases/d
 
 # https://github.com/grpc/grpc-web
 WORKDIR /tmp
-ARG GRPC_WEB_VERSION
+# renovate: datasource=github-releases depName=grpc-web packageName=grpc/grpc-web
+ARG GRPC_WEB_VERSION=1.5.0
 RUN curl -sSL "https://github.com/grpc/grpc-web/releases/download/${GRPC_WEB_VERSION}/protoc-gen-grpc-web-${GRPC_WEB_VERSION}-linux-x86_64" -o /usr/local/bin/protoc-gen-web-grpc && \
     chmod +x /usr/local/bin/protoc-gen-web-grpc
 
 # https://pkg.go.dev/google.golang.org/protobuf/cmd/protoc-gen-go
-ARG PROTOBUF_GO_VERSION
+# renovate: datasource=github-releases depName=protoc-gen-go packageName=google.golang.org/protobuf
+ARG PROTOBUF_GO_VERSION=1.36.3
 RUN GOBIN=/usr/local/bin go install google.golang.org/protobuf/cmd/protoc-gen-go@v${PROTOBUF_GO_VERSION}
 
 # https://pkg.go.dev/google.golang.org/grpc/cmd/protoc-gen-go-grpc
-ARG GRPC_GO_VERSION
+# renovate: datasource=github-releases depName=protoc-gen-go packageName=google.golang.org/grpc
+ARG GRPC_GO_VERSION=1.5.1
 RUN GOBIN=/usr/local/bin go install "google.golang.org/grpc/cmd/protoc-gen-go-grpc@v${GRPC_GO_VERSION}"
 
 # https://github.com/bufbuild/buf
-ARG BUF_VERSION
+# renovate: datasource=github-releases depName=buf packageName=bufbuild/buf
+ARG BUF_VERSION=1.50.0
 RUN GOBIN=/usr/local/bin go install \
     github.com/bufbuild/buf/cmd/buf@v${BUF_VERSION} \
     github.com/bufbuild/buf/cmd/protoc-gen-buf-breaking@v${BUF_VERSION} \
     github.com/bufbuild/buf/cmd/protoc-gen-buf-lint@v${BUF_VERSION}
 
 # Connect gRPC plugins
-ARG CONNECT_GO_VERSION
+# renovate: datasource=github-releases depName=protoc_gen_go packageName=protocolbuffers/protobuf-go
+ARG PROTOC_GEN_GO_VERSION=1.36.3
+# renovate: datasource=github-releases depName=protoc_gen_connect_go packageName=connectrpc/connect-go
+ARG PROTOC_GEN_CONNECT_GO_VERSION=1.18.1
 RUN GOBIN=/usr/local/bin go install \
-    connectrpc.com/connect/cmd/protoc-gen-connect-go@v${CONNECT_GO_VERSION}
+    connectrpc.com/connect/cmd/protoc-gen-connect-go@v${PROTOC_GEN_CONNECT_GO_VERSION}
 
 WORKDIR /
 
@@ -64,16 +73,19 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /tmp
 
-# https://github.com/grpc/grpc
 ARG bazel=/tmp/grpc/tools/bazel
-ARG GRPC_VERSION
+# https://github.com/grpc/grpc
+# renovate: datasource=github-releases depName=grpc/grpc packageName=grpc/grpc
+ARG GRPC_VERSION=1.69.0
 RUN git clone --depth 1 --shallow-submodules -b v${GRPC_VERSION} --recursive https://github.com/grpc/grpc
 WORKDIR /tmp/grpc
 RUN $bazel build //src/compiler:all
 
-# # https://github.com/grpc/grpc-java
+# https://github.com/grpc/grpc-java
 WORKDIR /tmp
-ARG GRPC_JAVA_VERSION
+
+# renovate: datasource=github-releases depName=grpc-java packageName=grpc/grpc-java
+ARG GRPC_JAVA_VERSION=1.69.1
 RUN git clone --depth 1 --shallow-submodules -b v${GRPC_JAVA_VERSION} --recursive https://github.com/grpc/grpc-java
 WORKDIR /tmp/grpc-java
 RUN $bazel build //compiler:grpc_java_plugin
@@ -88,16 +100,19 @@ FROM node:22-bookworm-slim
 # Install dependencies
 RUN apt-get update && apt-get install -y git
 
-# https://github.com/grpc/grpc-node/tree/master/packages/grpc-tools
-ARG GRPC_NODE_TOOLS_VERSION
-ARG PROTOBUF_PROTOPLUGIN_VERSION
-ARG PROTOBUF_ES_VERSION
-ARG CONNECT_ES_VERSION
+# https://www.npmjs.com/package/grpc-tools
+# renovate: datasource=npm depName=grpc-tools packageName=grpc-tools
+ARG GRPC_NODE_TOOLS_VERSION=1.12.4
+# https://www.npmjs.com/package/@bufbuild/protoplugin
+# renovate: datasource=npm depName=buf-protoplugin packageName=@bufbuild/protoplugin
+ARG PROTOBUF_PROTOPLUGIN_VERSION=2.2.3
+# https://www.npmjs.com/package/@bufbuild/protoc-gen-es
+# renovate: datasource=github-npm depName=protobuf-gen-es packageName=@bufbuild/protoc-gen-es
+ARG PROTOBUF_ES_VERSION=2.2.3
 RUN npm i -g \
     grpc-tools@${GRPC_NODE_TOOLS_VERSION} \
     @bufbuild/protoplugin@${PROTOBUF_PROTOPLUGIN_VERSION} \
-    @bufbuild/protoc-gen-es@${PROTOBUF_ES_VERSION} \
-    @connectrpc/protoc-gen-connect-es@${CONNECT_ES_VERSION}
+    @bufbuild/protoc-gen-es@${PROTOBUF_ES_VERSION}
 RUN cp /usr/local/lib/node_modules/grpc-tools/bin/grpc_node_plugin /usr/local/bin/protoc-gen-node-grpc
 
 # Copy protoc and well known proto files

--- a/README.md
+++ b/README.md
@@ -27,18 +27,17 @@ The image includes [Buf](https://buf.build/) to facilitate code generation, lint
 | Tool | Version |
 | - | - |
 | [buf](https://github.com/bufbuild/buf) | v1.40.1 |
-| [protoc](https://github.com/protocolbuffers/protobuf) | v28.0 |
-| [protoc-gen-go](https://pkg.go.dev/google.golang.org/protobuf/cmd/protoc-gen-go) | v1.34.2 |
+| [protoc](https://github.com/protocolbuffers/protobuf) | v29.3 |
+| [protoc-gen-go](https://pkg.go.dev/google.golang.org/protobuf/cmd/protoc-gen-go) | v1.36.3 |
 | [protoc-gen-js](https://github.com/protocolbuffers/protobuf-javascript) | v3.21.4 |
-| [protoplugin](https://www.npmjs.com/package/@bufbuild/protoplugin) | v2.0.0 |
-| [protoc-gen-es](https://www.npmjs.com/package/@bufbuild/protoc-gen-es) | v2.0.0 |
-| [grpc](https://github.com/grpc/grpc) | v1.66.1 |
+| [protoplugin](https://www.npmjs.com/package/@bufbuild/protoplugin) | v2.2.3 |
+| [protoc-gen-es](https://www.npmjs.com/package/@bufbuild/protoc-gen-es) | v2.2.3 |
+| [grpc](https://github.com/grpc/grpc) | v1.69.0 |
 | [protoc-gen-go-grpc](https://pkg.go.dev/google.golang.org/grpc/cmd/protoc-gen-go-grpc) | v1.5.1 |
-| [grpc-java](https://github.com/grpc/grpc-java) | v1.66.0 |
+| [grpc-java](https://github.com/grpc/grpc-java) | v1.69.1 |
 | [grpc-tools](https://www.npmjs.com/package/grpc-tools) | v1.12.4 |
 | [grpc-web](https://github.com/grpc/grpc-web) | v1.5.0 |
-| [protoc-gen-connect-go](https://github.com/connectrpc/connect-go) | v1.16.2 |
-| [protoc-gen-connect-es](https://github.com/connectrpc/connect-es) | v1.4.0 |
+| [protoc-gen-connect-go](https://github.com/connectrpc/connect-go) | v1.18.1 |
 
 ## Example
 

--- a/renovate.json
+++ b/renovate.json
@@ -17,9 +17,6 @@
       ]
     }
   ],
-  "enabledManagers": [
-    "dockerfile"
-  ],
   "groupName": "all dependencies",
   "groupSlug": "all"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,10 @@
       ]
     }
   ],
+  "enabledManagers": [
+    "dockerfile",
+    "custom.regex"
+  ],
   "groupName": "all dependencies",
   "groupSlug": "all"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update _VERSION variables in Dockerfiles",
+      "fileMatch": [
+        "(^|/|\\.)Dockerfile$",
+        "(^|/)Dockerfile\\.[^/]*$",
+        "(^|/)versions.env$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG) .+?_VERSION=(?<currentValue>.+?)\\s"
+      ]
+    }
+  ],
+  "enabledManagers": [
+    "dockerfile"
+  ],
+  "groupName": "all dependencies",
+  "groupSlug": "all"
+}

--- a/versions.env
+++ b/versions.env
@@ -1,16 +1,41 @@
 BUF_VERSION=1.40.1
 
-PROTOBUF_VERSION=28.0
-PROTOBUF_GO_VERSION=1.34.2
+# https://github.com/protocolbuffers/protobuf
+# renovate: datasource=github-releases depName=protoc packageName=protocolbuffers/protobuf
+PROTOBUF_VERSION=29.3
+# https://pkg.go.dev/google.golang.org/protobuf/cmd/protoc-gen-go
+# renovate: datasource=github-releases depName=protoc-gen-go packageName=google.golang.org/protobuf
+PROTOBUF_GO_VERSION=1.36.3
+# https://github.com/protocolbuffers/protobuf-javascript
+# renovate: datasource=github-releases depName=protobuf-javascript packageName=protocolbuffers/protobuf-javascript
 PROTOBUF_JAVASCRIPT_VERSION=3.21.4
-PROTOBUF_PROTOPLUGIN_VERSION=2.0.0
-PROTOBUF_ES_VERSION=2.0.0
+# https://www.npmjs.com/package/@bufbuild/protoplugin
+# renovate: datasource=npm depName=buf-protoplugin packageName=@bufbuild/protoplugin
+PROTOBUF_PROTOPLUGIN_VERSION=2.2.3
+# https://www.npmjs.com/package/@bufbuild/protoc-gen-es
+# renovate: datasource=github-npm depName=protobuf-gen-es packageName=@bufbuild/protoc-gen-es
+PROTOBUF_ES_VERSION=2.2.3
 
-GRPC_VERSION=1.66.1
+# https://github.com/grpc/grpc
+# renovate: datasource=github-releases depName=grpc/grpc packageName=grpc/grpc
+GRPC_VERSION=1.69.0
+# https://pkg.go.dev/google.golang.org/grpc/cmd/protoc-gen-go-grpc
+# renovate: datasource=github-releases depName=protoc-gen-go packageName=google.golang.org/grpc
 GRPC_GO_VERSION=1.5.1
-GRPC_JAVA_VERSION=1.66.0
+# https://github.com/grpc/grpc-java
+# renovate: datasource=github-releases depName=grpc-java packageName=grpc/grpc-java
+GRPC_JAVA_VERSION=1.69.1
+# https://www.npmjs.com/package/grpc-tools
+# renovate: datasource=npm depName=grpc-tools packageName=grpc-tools
 GRPC_NODE_TOOLS_VERSION=1.12.4
+# https://github.com/grpc/grpc-web
+# renovate: datasource=github-releases depName=grpc-web packageName=grpc/grpc-web
 GRPC_WEB_VERSION=1.5.0
 
-CONNECT_GO_VERSION=1.16.2
-CONNECT_ES_VERSION=1.4.0
+# https://github.com/connectrpc/connect-go
+# renovate: datasource=github-releases depName=protoc_gen_connect_go packageName=connectrpc/connect-go
+PROTOC_GEN_CONNECT_GO_VERSION=1.18.1
+
+
+
+

--- a/versions.env
+++ b/versions.env
@@ -1,12 +1,12 @@
 # https://github.com/bufbuild/buf
-# renovate: datasource=golang depName=buf packageName=bufbuild/buf
+# renovate: datasource=go depName=buf packageName=bufbuild/buf
 BUF_VERSION=1.40.1
 
 # https://github.com/protocolbuffers/protobuf
 # renovate: datasource=github-releases depName=protoc packageName=protocolbuffers/protobuf
 PROTOBUF_VERSION=29.3
 # https://pkg.go.dev/google.golang.org/protobuf/cmd/protoc-gen-go
-# renovate: datasource=golang depName=protoc-gen-go packageName=google.golang.org/protobuf
+# renovate: datasource=go depName=protoc-gen-go packageName=google.golang.org/protobuf
 PROTOBUF_GO_VERSION=1.36.3
 # https://github.com/protocolbuffers/protobuf-javascript
 # renovate: datasource=github-releases depName=protobuf-javascript packageName=protocolbuffers/protobuf-javascript
@@ -15,14 +15,14 @@ PROTOBUF_JAVASCRIPT_VERSION=3.21.4
 # renovate: datasource=npm depName=buf-protoplugin packageName=@bufbuild/protoplugin
 PROTOBUF_PROTOPLUGIN_VERSION=2.2.3
 # https://www.npmjs.com/package/@bufbuild/protoc-gen-es
-# renovate: datasource=github-npm depName=protobuf-gen-es packageName=@bufbuild/protoc-gen-es
+# renovate: datasource=npm depName=protobuf-gen-es packageName=@bufbuild/protoc-gen-es
 PROTOBUF_ES_VERSION=2.2.3
 
 # https://github.com/grpc/grpc
 # renovate: datasource=github-releases depName=grpc/grpc packageName=grpc/grpc
 GRPC_VERSION=1.69.0
 # https://pkg.go.dev/google.golang.org/grpc/cmd/protoc-gen-go-grpc
-# renovate: datasource=golang depName=protoc-gen-go packageName=google.golang.org/grpc
+# renovate: datasource=go depName=protoc-gen-go packageName=google.golang.org/grpc
 GRPC_GO_VERSION=1.5.1
 # https://github.com/grpc/grpc-java
 # renovate: datasource=github-releases depName=grpc-java packageName=grpc/grpc-java
@@ -35,7 +35,7 @@ GRPC_NODE_TOOLS_VERSION=1.12.4
 GRPC_WEB_VERSION=1.5.0
 
 # https://github.com/connectrpc/connect-go
-# renovate: datasource=golang depName=protoc_gen_connect_go packageName=connectrpc/connect-go
+# renovate: datasource=go depName=protoc_gen_connect_go packageName=connectrpc/connect-go
 PROTOC_GEN_CONNECT_GO_VERSION=1.18.1
 
 

--- a/versions.env
+++ b/versions.env
@@ -22,7 +22,7 @@ PROTOBUF_ES_VERSION=2.2.3
 # renovate: datasource=github-releases depName=grpc/grpc packageName=grpc/grpc
 GRPC_VERSION=1.69.0
 # https://pkg.go.dev/google.golang.org/grpc/cmd/protoc-gen-go-grpc
-# renovate: datasource=go depName=protoc-gen-go packageName=google.golang.org/grpc/cmd/protoc-gen-go-grpc
+# renovate: datasource=go depName=protoc-gen-go-grpc packageName=google.golang.org/grpc/cmd/protoc-gen-go-grpc
 GRPC_GO_VERSION=1.5.1
 # https://github.com/grpc/grpc-java
 # renovate: datasource=github-releases depName=grpc-java packageName=grpc/grpc-java

--- a/versions.env
+++ b/versions.env
@@ -34,7 +34,7 @@ GRPC_NODE_TOOLS_VERSION=1.12.4
 # renovate: datasource=github-releases depName=grpc-web packageName=grpc/grpc-web
 GRPC_WEB_VERSION=1.5.0
 
-# renovate: datasource=go depName=protoc_gen_connect_go packageName=connectrpc.com/connect/cmd/protoc-gen-connect-go
+# renovate: datasource=github-releases depName=protoc_gen_connect_go packageName=connectrpc/connect-go
 PROTOC_GEN_CONNECT_GO_VERSION=1.18.1
 
 

--- a/versions.env
+++ b/versions.env
@@ -1,12 +1,12 @@
 # https://github.com/bufbuild/buf
-# renovate: datasource=go depName=buf packageName=bufbuild/buf
-BUF_VERSION=1.40.1
+# renovate: datasource=go depName=buf packageName=github.com/bufbuild/buf/cmd/buf
+BUF_VERSION=1.50.0
 
 # https://github.com/protocolbuffers/protobuf
 # renovate: datasource=github-releases depName=protoc packageName=protocolbuffers/protobuf
 PROTOBUF_VERSION=29.3
 # https://pkg.go.dev/google.golang.org/protobuf/cmd/protoc-gen-go
-# renovate: datasource=go depName=protoc-gen-go packageName=google.golang.org/protobuf
+# renovate: datasource=go depName=protoc-gen-go packageName=google.golang.org/protobuf/cmd/protoc-gen-go
 PROTOBUF_GO_VERSION=1.36.3
 # https://github.com/protocolbuffers/protobuf-javascript
 # renovate: datasource=github-releases depName=protobuf-javascript packageName=protocolbuffers/protobuf-javascript
@@ -22,7 +22,7 @@ PROTOBUF_ES_VERSION=2.2.3
 # renovate: datasource=github-releases depName=grpc/grpc packageName=grpc/grpc
 GRPC_VERSION=1.69.0
 # https://pkg.go.dev/google.golang.org/grpc/cmd/protoc-gen-go-grpc
-# renovate: datasource=go depName=protoc-gen-go packageName=google.golang.org/grpc
+# renovate: datasource=go depName=protoc-gen-go packageName=google.golang.org/grpc/cmd/protoc-gen-go-grpc
 GRPC_GO_VERSION=1.5.1
 # https://github.com/grpc/grpc-java
 # renovate: datasource=github-releases depName=grpc-java packageName=grpc/grpc-java
@@ -34,8 +34,7 @@ GRPC_NODE_TOOLS_VERSION=1.12.4
 # renovate: datasource=github-releases depName=grpc-web packageName=grpc/grpc-web
 GRPC_WEB_VERSION=1.5.0
 
-# https://github.com/connectrpc/connect-go
-# renovate: datasource=go depName=protoc_gen_connect_go packageName=connectrpc/connect-go
+# renovate: datasource=go depName=protoc_gen_connect_go packageName=connectrpc.com/connect/cmd/protoc-gen-connect-go
 PROTOC_GEN_CONNECT_GO_VERSION=1.18.1
 
 

--- a/versions.env
+++ b/versions.env
@@ -1,10 +1,12 @@
+# https://github.com/bufbuild/buf
+# renovate: datasource=golang depName=buf packageName=bufbuild/buf
 BUF_VERSION=1.40.1
 
 # https://github.com/protocolbuffers/protobuf
 # renovate: datasource=github-releases depName=protoc packageName=protocolbuffers/protobuf
 PROTOBUF_VERSION=29.3
 # https://pkg.go.dev/google.golang.org/protobuf/cmd/protoc-gen-go
-# renovate: datasource=github-releases depName=protoc-gen-go packageName=google.golang.org/protobuf
+# renovate: datasource=golang depName=protoc-gen-go packageName=google.golang.org/protobuf
 PROTOBUF_GO_VERSION=1.36.3
 # https://github.com/protocolbuffers/protobuf-javascript
 # renovate: datasource=github-releases depName=protobuf-javascript packageName=protocolbuffers/protobuf-javascript
@@ -20,7 +22,7 @@ PROTOBUF_ES_VERSION=2.2.3
 # renovate: datasource=github-releases depName=grpc/grpc packageName=grpc/grpc
 GRPC_VERSION=1.69.0
 # https://pkg.go.dev/google.golang.org/grpc/cmd/protoc-gen-go-grpc
-# renovate: datasource=github-releases depName=protoc-gen-go packageName=google.golang.org/grpc
+# renovate: datasource=golang depName=protoc-gen-go packageName=google.golang.org/grpc
 GRPC_GO_VERSION=1.5.1
 # https://github.com/grpc/grpc-java
 # renovate: datasource=github-releases depName=grpc-java packageName=grpc/grpc-java
@@ -33,7 +35,7 @@ GRPC_NODE_TOOLS_VERSION=1.12.4
 GRPC_WEB_VERSION=1.5.0
 
 # https://github.com/connectrpc/connect-go
-# renovate: datasource=github-releases depName=protoc_gen_connect_go packageName=connectrpc/connect-go
+# renovate: datasource=golang depName=protoc_gen_connect_go packageName=connectrpc/connect-go
 PROTOC_GEN_CONNECT_GO_VERSION=1.18.1
 
 


### PR DESCRIPTION
Hi, this PR automates updating the `Dockerfile` and `versions.env` using Renovate. Renovate is a service similar to GitHub Dependabot, but with (fantastically) more configuration options.  So many options in fact, if you're new you may want to gloss over [this cheat-sheet](https://www.augmentedmind.de/2021/07/25/renovate-bot-cheat-sheet](https://www.augmentedmind.de/2021/07/25/renovate-bot-cheat-sheet) prior to the official documentation.

This PR adds comments to the `Dockerfile` file such that a new [Renovate Bot](https://docs.renovatebot.com/) configuration with a custom regex will automatically update the Docker file when any new versions of the tools are released in the variety of package managers (go packages, npm packages, debian packages, etc.).

These comment "hints" in the `Dockerfile` file will help Renovate find the correct packages to update the version information. The `renovate.json` contains a custom regex manager that will use these hints and update the next line based on the preceding comment's datasource's packageName, and mostly just use the comment's depName as a "displayName" for logging purposes. In addition, there's regular Docker file config that updates the base images.

I also removed the [protoc-gen-connect-es](https://www.npmjs.com/package/@connectrpc/protoc-gen-connect-es) as it is not longer necessary with the [2.0 release of the connect framework](https://github.com/connectrpc/connect-es/releases/tag/v2.0.0).

Fixes #9
---

By the way, I got this technique from https://gitlab.com/kohenkatz/grpc-connect-buf via @kohenkatz
